### PR TITLE
fix variable compare

### DIFF
--- a/practica/tp1/ejercicio6.sh
+++ b/practica/tp1/ejercicio6.sh
@@ -2,12 +2,12 @@
 # shscript
 
 	toggle="A"
-	if [ $1 == "-p" ]; then
+	if [ "$1" = "-p" ]; then
 		toggle="B"
   	fi
  	while read line
  	do
- 		if [ $toggle == "A" ]; then
+ 		if [ "$toggle" = "A" ]; then
  			echo $line
  			toggle="B"
  		else


### PR DESCRIPTION
El error se reproduce invocando al script sin parámetros.
Corrige la comparación de variables para respetar la sintaxis bash y evitar el error.